### PR TITLE
refactor: handle data availability on direct load

### DIFF
--- a/src/pages/Rocket/Detail.vue
+++ b/src/pages/Rocket/Detail.vue
@@ -48,8 +48,13 @@ const route = useRoute();
 const store = useRocketStore();
 const rocket = ref<IDataRocket | null>(null);
 
-onMounted(() => {
+onMounted(async() => {
   const id = route.params.id as string;
+
+  if (store.rockets.length === 0) {
+    await store.loadRockets();
+  }
+
   rocket.value = store.rockets.find(r => r.id === id) || null;
 });
 </script>


### PR DESCRIPTION
## Overview
This fixes a bug that made the rocket detail page show up empty when it was refreshed or opened from a direct link.

## Changes
- Modified pages/Rocket/Detail.vue: Updated the onMounted lifecycle hook to check if the Pinia store for rockets is empty. If the store is empty, the component now automatically calls the loadRockets action to fetch the necessary data before rendering the rocket's details.